### PR TITLE
Comment out version of ansible-nginx

### DIFF
--- a/roles/requirements.yml
+++ b/roles/requirements.yml
@@ -28,6 +28,6 @@
   path : external
 
 - src: git+https://github.com/yetu/ansible-nginx.git
-  version: "v1.0.1"
+  #version: "v1.0.1"
   name: ansible-nginx
   path : external


### PR DESCRIPTION
The 'ansible-nginx' repository at https://github.com/yetu/ansible-nginx appears to not have any "releases" or "tags".
Therefore, when trying to run `ansible-galaxy install -r requirements.yml` the following error is produced:

```- executing: git clone https://github.com/yetu/ansible-nginx.git yetu.ansible-nginx
- executing: git archive --prefix=yetu.ansible-nginx/
  --output=/var/folders/01/fswx1t811p3_q5bj53yjfhnw0000gn/T/tmpxurhAf.tar v1.0.1
- command git archive --prefix=yetu.ansible-nginx/
  --output=/var/folders/01/fswx1t811p3_q5bj53yjfhnw0000gn/T/tmpxurhAf.tar v1.0.1 failed
  in directory /var/folders/01/fswx1t811p3_q5bj53yjfhnw0000gn/T/tmp6UmHQX
- yetu.ansible-nginx was NOT installed successfully.
- you can use --ignore-errors to skip failed roles.```

Commenting out the version and running the command again installs the module successfully.

It might be worthwhile reporting this as an issue upstream to allow "ansible-galaxy" to better handle this situation
(i.e. provide a more meaningful error message or even check that the version exists prior to download)